### PR TITLE
Fix: check correct token when checking for native token

### DIFF
--- a/apps/flame-defi/app/swap/hooks/use-get-quote.tsx
+++ b/apps/flame-defi/app/swap/hooks/use-get-quote.tsx
@@ -45,7 +45,7 @@ export const useGetQuote = () => {
       const tokenInDecimals = tokenOne?.token?.coinDecimals;
       const tokenInSymbol = tokenOne?.token?.coinDenom.toLocaleLowerCase();
 
-      const tokenOutAddress = tokenOne?.token?.isNative
+      const tokenOutAddress = tokenTwo?.token?.isNative
         ? chainContracts?.wrappedNativeToken.address
         : tokenTwo?.token?.erc20ContractAddress;
       const tokenOutDecimals = tokenTwo?.token?.coinDecimals;


### PR DESCRIPTION
Bad copy/paste bug where I was checking tokenOne for both input and output