### PR TITLE
Fix: fix issue with getting usdc exactOut quote

### DIFF
--- a/apps/flame-defi/app/hooks/use-get-quote.tsx
+++ b/apps/flame-defi/app/hooks/use-get-quote.tsx
@@ -16,8 +16,8 @@ export const useGetQuote = () => {
   const getQuote = useCallback(
     async (
       tradeType: TRADE_TYPE,
-      tokenIn: TokenInputState,
-      tokenOut: TokenInputState,
+      tokenIn: Omit<TokenInputState, "isQuoteValue">,
+      tokenOut: Omit<TokenInputState, "isQuoteValue">,
     ): Promise<GetQuoteResult | undefined> => {
       abortControllerRef.current = new AbortController();
       // tokens must exist

--- a/apps/flame-defi/app/hooks/use-get-quote.tsx
+++ b/apps/flame-defi/app/hooks/use-get-quote.tsx
@@ -110,7 +110,7 @@ export const useGetQuote = () => {
         setLoading(false);
       }
     },
-    [chainId, chainContracts?.wrappedNativeToken.address],
+    [chainId, chainContracts.wrappedNativeToken.address],
   );
 
   const cancelGetQuote = useCallback(() => {

--- a/apps/flame-defi/app/swap/components/swap-input.tsx
+++ b/apps/flame-defi/app/swap/components/swap-input.tsx
@@ -12,7 +12,6 @@ export function SwapInput({
   availableTokens,
   balance,
   id,
-  index,
   inputToken,
   label,
   onInputChange,
@@ -71,7 +70,7 @@ export function SwapInput({
             type="number"
             value={inputToken.value}
             onChange={(e) => {
-              onInputChange(e.target.value, id, index);
+              onInputChange(e.target.value, id);
             }}
             className="normalize-input w-[45%] sm:max-w-[62%] text-ellipsis overflow-hidden text-[36px]"
             placeholder="0"
@@ -82,7 +81,9 @@ export function SwapInput({
             tokens={availableTokens}
             selectedToken={inputToken.token}
             unavailableToken={oppositeToken?.token}
-            setSelectedToken={(token) => onTokenSelect(token, id, index)}
+            setSelectedToken={(token) =>
+              onTokenSelect(token, oppositeToken, id)
+            }
           />
           {inputToken.token && balance && !isDustAmount(balance) ? (
             <div className="text-sm font-medium text-grey-light flex items-center mt-3">
@@ -96,7 +97,7 @@ export function SwapInput({
               {
                 <span
                   onClick={() => {
-                    onInputChange(balance, id, index);
+                    onInputChange(balance, id);
                   }}
                   className="px-3 py-0 ml-2 rounded-2xl bg-grey-dark hover:bg-grey-medium text-orange-soft text-sm cursor-pointer transition"
                 >

--- a/apps/flame-defi/app/swap/components/swap-input.tsx
+++ b/apps/flame-defi/app/swap/components/swap-input.tsx
@@ -44,8 +44,8 @@ export function SwapInput({
 
     if (inputToken.token?.coinDenom === "USDC" && inputToken.value !== "") {
       return formatFiat(inputToken.value);
-    } else if (usdQuote?.quote) {
-      return formatFiat(usdQuote?.quote?.quoteDecimals);
+    } else if (usdQuote.quote) {
+      return formatFiat(usdQuote.quote.quoteDecimals);
     } else {
       return "-";
     }
@@ -80,7 +80,7 @@ export function SwapInput({
           <TokenSelector
             tokens={availableTokens}
             selectedToken={inputToken.token}
-            unavailableToken={oppositeToken?.token}
+            unavailableToken={oppositeToken.token}
             setSelectedToken={(token) =>
               onTokenSelect(token, oppositeToken, id)
             }
@@ -92,7 +92,7 @@ export function SwapInput({
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 4,
                 })}{" "}
-                {inputToken?.token?.coinDenom}
+                {inputToken.token?.coinDenom}
               </span>
               {
                 <span
@@ -112,7 +112,7 @@ export function SwapInput({
       </div>
       <div>
         <Skeleton
-          isLoading={usdQuote?.loading || txnQuoteLoading}
+          isLoading={usdQuote.loading || txnQuoteLoading}
           className="rounded-sm w-[70px]"
         >
           <span className="text-sm font-medium text-grey-light">

--- a/apps/flame-defi/app/swap/components/swap-txn-steps.tsx
+++ b/apps/flame-defi/app/swap/components/swap-txn-steps.tsx
@@ -34,19 +34,19 @@ export function TxnDetails({
     <>
       <div className="flex flex-col items-center gap-3 mb-8 mt-6 relative">
         <div className="flex justify-between bg-semi-white border border-solid border-grey-medium p-4 rounded-xl w-full text-lg">
-          <span>{formatDecimalValues(topToken?.value || "0", 6)}</span>
+          <span>{formatDecimalValues(topToken.value || "0", 6)}</span>
           <span className="flex items-center gap-1">
-            {topToken?.token?.IconComponent &&
-              topToken?.token?.IconComponent({ size: 24 })}
-            {topToken?.token?.coinDenom}
+            {topToken.token?.IconComponent &&
+              topToken.token.IconComponent({ size: 24 })}
+            {topToken.token?.coinDenom}
           </span>
         </div>
         <div className="flex justify-between bg-semi-white border border-solid border-grey-medium p-4 rounded-xl text-md w-full text-lg">
           <span>{expectedOutputFormatted}</span>
           <span className="flex items-center gap-1">
-            {bottomToken?.token?.IconComponent &&
-              bottomToken?.token?.IconComponent({ size: 24 })}
-            {bottomToken?.token?.coinDenom}
+            {bottomToken.token?.IconComponent &&
+              bottomToken.token.IconComponent({ size: 24 })}
+            {bottomToken.token?.coinDenom}
           </span>
         </div>
         <div className="absolute top-1/2 transform -translate-y-1/2 flex justify-center">
@@ -85,7 +85,7 @@ export function TxnDetails({
           </span>
           <span className="text-grey-light text-sm font-medium">
             {expectedOutputFormatted}{" "}
-            <span>{bottomToken?.token?.coinDenom}</span>
+            <span>{bottomToken.token?.coinDenom}</span>
           </span>
         </div>
         <div className="flex justify-between">
@@ -113,7 +113,7 @@ export function TxnDetails({
           </div>
           <div className="text-grey-light flex items-center gap-1 text-sm font-medium">
             <span>{minimumReceived}</span>
-            <span>{bottomToken?.token?.coinDenom}</span>
+            <span>{bottomToken.token?.coinDenom}</span>
           </div>
         </div>
       </div>
@@ -136,15 +136,15 @@ function TxnLoader({
         </span>
         <div className="flex items-center gap-1 justify-center text-sm md:text-base">
           <span>
-            {formatDecimalValues(topToken?.value || "0", 6)}{" "}
-            <span>{topToken?.token?.coinDenom}</span>
+            {formatDecimalValues(topToken.value || "0", 6)}{" "}
+            <span>{topToken.token?.coinDenom}</span>
           </span>
           <span>for</span>
           <span>
             {isTiaWtia
-              ? formatDecimalValues(bottomToken?.value || "0", 6)
+              ? formatDecimalValues(bottomToken.value || "0", 6)
               : expectedOutputFormatted}{" "}
-            <span> {bottomToken?.token?.coinDenom}</span>
+            <span> {bottomToken.token?.coinDenom}</span>
           </span>
         </div>
       </div>
@@ -169,16 +169,16 @@ function TxnSuccess({
           <div className="flex items-center gap-1">
             <span>Swapped</span>
             <span>
-              {formatDecimalValues(topToken?.value || "0", 6)}{" "}
-              <span>{topToken?.token?.coinDenom}</span>
+              {formatDecimalValues(topToken.value || "0", 6)}{" "}
+              <span>{topToken.token?.coinDenom}</span>
             </span>
           </div>
           <span>for</span>
           <div className="flex items-center gap-1">
             {isTiaWtia
-              ? formatDecimalValues(bottomToken?.value || "0", 6)
+              ? formatDecimalValues(bottomToken.value || "0", 6)
               : expectedOutputFormatted}{" "}
-            <span>{bottomToken?.token?.coinDenom}</span>
+            <span>{bottomToken.token?.coinDenom}</span>
           </div>
         </div>
         <div className="flex items-center gap-1 justify-center text-base">
@@ -196,7 +196,7 @@ function TxnSuccess({
   );
 }
 
-function TxnFailed({ txnMsg }: TxnStepsProps) {
+function TxnFailed({ txnMsg }: Pick<TxnStepsProps, "txnMsg">) {
   return (
     <div className="flex flex-col items-center justify-center h-full">
       <ErrorIcon size={170} className="text-orange-soft" />

--- a/apps/flame-defi/app/swap/components/txn-info.tsx
+++ b/apps/flame-defi/app/swap/components/txn-info.tsx
@@ -15,15 +15,12 @@ import { useTxnInfo } from "../hooks";
 import { OneToOneQuoteProps } from "../types";
 import { RoutePath } from "./route-path";
 
-enum TOKEN_INPUTS {
-  TOKEN_ONE = "token_one",
-  TOKEN_TWO = "token_two",
-}
-
 export interface TxnInfoProps {
-  id: TOKEN_INPUTS;
-  inputToken: TokenInputState;
   txnInfo: ReturnType<typeof useTxnInfo>;
+  topToken: TokenInputState;
+  bottomToken: TokenInputState;
+  oneToOneQuote: OneToOneQuoteProps;
+  quote: GetQuoteResult;
 }
 
 export function TxnInfo({
@@ -32,13 +29,7 @@ export function TxnInfo({
   bottomToken,
   oneToOneQuote,
   quote,
-}: {
-  txnInfo: ReturnType<typeof useTxnInfo>;
-  topToken: TokenInputState;
-  bottomToken: TokenInputState;
-  oneToOneQuote: OneToOneQuoteProps;
-  quote: GetQuoteResult;
-}) {
+}: TxnInfoProps) {
   const swapSlippageTolerance = getSwapSlippageTolerance();
 
   return (
@@ -50,22 +41,22 @@ export function TxnInfo({
         <div className="flex items-center justify-between pb-2">
           <Skeleton
             className="rounded-sm"
-            isLoading={oneToOneQuote?.oneToOneLoading}
+            isLoading={oneToOneQuote.oneToOneLoading}
           >
             <div
               className="flex items-center cursor-pointer text-white font-medium gap-1"
               onClick={() =>
-                oneToOneQuote?.setFlipDirection(!oneToOneQuote?.flipDirection)
+                oneToOneQuote.setFlipDirection(!oneToOneQuote.flipDirection)
               }
             >
               <div className="flex items-center gap-1">
                 <span>{formatDecimalValues("1", 0)}</span>
-                <span>{oneToOneQuote?.topTokenSymbol}</span>
+                <span>{oneToOneQuote.topTokenSymbol}</span>
               </div>
               <div>=</div>
               <div className="flex items-center gap-1">
-                <span>{oneToOneQuote?.bottomTokenValue}</span>
-                <span>{oneToOneQuote?.bottomTokenSymbol}</span>
+                <span>{oneToOneQuote.bottomTokenValue}</span>
+                <span>{oneToOneQuote.bottomTokenSymbol}</span>
               </div>
             </div>
           </Skeleton>
@@ -98,7 +89,7 @@ export function TxnInfo({
               </span>
               <span className="text-grey-light">
                 {txnInfo.expectedOutputFormatted}{" "}
-                <span>{bottomToken?.token?.coinDenom}</span>
+                <span>{bottomToken.token?.coinDenom}</span>
               </span>
             </p>
             <p className="flex justify-between">
@@ -136,7 +127,7 @@ export function TxnInfo({
               </div>
               <span className="text-grey-light">
                 {txnInfo.minimumReceived}{" "}
-                <span>{bottomToken?.token?.coinDenom}</span>
+                <span>{bottomToken.token?.coinDenom}</span>
               </span>
             </div>
           </div>
@@ -145,8 +136,8 @@ export function TxnInfo({
             <RoutePath
               quoteRoute={quote.route}
               loading={txnInfo.txnQuoteDataLoading}
-              symbolIn={topToken?.token?.coinDenom}
-              symbolOut={bottomToken?.token?.coinDenom}
+              symbolIn={topToken.token?.coinDenom}
+              symbolOut={bottomToken.token?.coinDenom}
               networkFee={txnInfo.formattedGasUseEstimateUSD}
             />
           )}

--- a/apps/flame-defi/app/swap/components/txn-info.tsx
+++ b/apps/flame-defi/app/swap/components/txn-info.tsx
@@ -11,12 +11,11 @@ import {
 } from "@repo/ui/shadcn-primitives";
 import { formatDecimalValues, getSwapSlippageTolerance } from "@repo/ui/utils";
 import { GetQuoteResult } from "@repo/flame-types";
-import { useTxnInfo } from "../hooks";
-import { OneToOneQuoteProps } from "../types";
+import { OneToOneQuoteProps, TransactionInfo } from "../types";
 import { RoutePath } from "./route-path";
 
 export interface TxnInfoProps {
-  txnInfo: ReturnType<typeof useTxnInfo>;
+  txnInfo: TransactionInfo;
   topToken: TokenInputState;
   bottomToken: TokenInputState;
   oneToOneQuote: OneToOneQuoteProps;

--- a/apps/flame-defi/app/swap/hooks/use-swap-button.tsx
+++ b/apps/flame-defi/app/swap/hooks/use-swap-button.tsx
@@ -49,13 +49,13 @@ const useCheckTokenApproval = (
 
   const findApproval = (token: TokenInputState) =>
     tokenAllowances.find(
-      (allowanceToken) => allowanceToken.symbol === token?.token?.coinDenom,
+      (allowanceToken) => allowanceToken.symbol === token.token?.coinDenom,
     );
 
-  const topTokenNeedingApproval = topToken?.token
+  const topTokenNeedingApproval = topToken.token
     ? findApproval(topToken)
     : null;
-  const bottomTokenNeedingApproval = bottomToken?.token
+  const bottomTokenNeedingApproval = bottomToken.token
     ? findApproval(bottomToken)
     : null;
 
@@ -101,12 +101,12 @@ export function useSwapButton({
   const tokenNeedingApproval = useCheckTokenApproval(topToken, bottomToken);
 
   const wrapTia =
-    topToken?.token?.isNative && bottomToken?.token?.isWrappedNative;
+    topToken.token?.isNative && bottomToken.token?.isWrappedNative;
   const unwrapTia =
-    topToken?.token?.isWrappedNative && bottomToken?.token?.isNative;
+    topToken.token?.isWrappedNative && bottomToken.token?.isNative;
 
-  const handleTxnModalErrorMsgs = (error?: string, defaultMsg?: string) => {
-    if (error?.includes("rejected")) {
+  const handleTxnModalErrorMsgs = (error: string, defaultMsg?: string) => {
+    if (error.includes("rejected")) {
       setTxnMsg("Transaction rejected");
     } else if (defaultMsg) {
       setTxnMsg(defaultMsg);
@@ -140,8 +140,8 @@ export function useSwapButton({
   }, [result.data, txnHash, addRecentTransaction]);
 
   const handleWrap = async (type: "wrap" | "unwrap") => {
-    const wtiaAddress = selectedChain.contracts?.wrappedNativeToken.address;
-    if (!selectedChain?.chainId || !wtiaAddress) {
+    const wtiaAddress = selectedChain.contracts.wrappedNativeToken.address;
+    if (!selectedChain.chainId || !wtiaAddress) {
       return;
     }
     setTxnStatus(TXN_STATUS.PENDING);
@@ -187,12 +187,12 @@ export function useSwapButton({
   }, [quote, tradeType]);
 
   const handleSwap = useCallback(async () => {
-    if (!trade || !userAccount.address || !selectedChain?.chainId) {
+    if (!trade || !userAccount.address || !selectedChain.chainId) {
       return;
     }
     setTxnStatus(TXN_STATUS.PENDING);
     try {
-      const swapRouterAddress = selectedChain.contracts?.swapRouter.address;
+      const swapRouterAddress = selectedChain.contracts.swapRouter.address;
       if (!swapRouterAddress) {
         console.warn("Swap router address is not defined. Cannot swap.");
         return;
@@ -260,17 +260,18 @@ export function useSwapButton({
     }
   };
 
+  // FIXME - parseFloat is not sufficient for huge numbers
   const validSwapInputs = Boolean(
     !loading &&
       txnStatus !== TXN_STATUS.PENDING &&
       errorText === null &&
-      topToken?.token &&
-      bottomToken?.token &&
-      topToken?.value !== undefined &&
-      bottomToken?.value !== undefined &&
-      parseFloat(topToken?.value) > 0 &&
-      parseFloat(bottomToken?.value) > 0 &&
-      parseFloat(topToken?.value) <= parseFloat(topTokenBalance),
+      topToken.token &&
+      bottomToken.token &&
+      topToken.value !== undefined &&
+      bottomToken.value !== undefined &&
+      parseFloat(topToken.value) > 0 &&
+      parseFloat(bottomToken.value) > 0 &&
+      parseFloat(topToken.value) <= parseFloat(topTokenBalance),
   );
 
   const onSubmitCallback = () => {
@@ -290,28 +291,29 @@ export function useSwapButton({
     }
   };
 
+  // FIXME - parseFloat is not sufficient for huge numbers
   const getButtonText = () => {
     switch (true) {
       case !userAccount.address:
         return "Connect Wallet";
-      case !topToken?.token || !bottomToken?.token:
+      case !topToken.token || !bottomToken.token:
         return "Select a token";
       case tokenNeedingApproval !== null && txnStatus !== TXN_STATUS.PENDING:
-        return `Approve ${tokenNeedingApproval?.coinDenom}`;
+        return `Approve ${tokenNeedingApproval.coinDenom}`;
       case tokenNeedingApproval !== null && txnStatus === TXN_STATUS.PENDING:
         return "Pending wallet approval...";
       case txnStatus === TXN_STATUS.PENDING:
         return "Pending...";
-      case topToken?.value === undefined:
+      case topToken.value === undefined:
         return "Enter an amount";
-      case parseFloat(topToken?.value) === 0 || parseFloat(topToken?.value) < 0:
+      case parseFloat(topToken.value) === 0 || parseFloat(topToken.value) < 0:
         return "Amount must be greater than 0";
       case loading:
         return "loading...";
-      case isNaN(parseFloat(topToken?.value)):
+      case isNaN(parseFloat(topToken.value)):
         return "Enter an amount";
       case topTokenBalance === "0" ||
-        parseFloat(topTokenBalance) < parseFloat(topToken?.value):
+        parseFloat(topTokenBalance) < parseFloat(topToken.value):
         return "Insufficient funds";
       case wrapTia:
         return "Wrap";

--- a/apps/flame-defi/app/swap/hooks/use-txn-info.tsx
+++ b/apps/flame-defi/app/swap/hooks/use-txn-info.tsx
@@ -164,7 +164,7 @@ export const useTxnInfo = ({
 
   return {
     txnQuoteDataLoading: txnQuoteLoading,
-    gasUseEstimateUSD: txnQuoteData?.gasUseEstimateUSD,
+    gasUseEstimateUSD: txnQuoteData?.gasUseEstimateUSD || "0",
     formattedGasUseEstimateUSD: formatNumber(
       parseFloat(txnQuoteData?.gasUseEstimateUSD || "0"),
       { minimumFractionDigits: 4, maximumFractionDigits: 4 },

--- a/apps/flame-defi/app/swap/hooks/use-txn-info.tsx
+++ b/apps/flame-defi/app/swap/hooks/use-txn-info.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useIntl } from "react-intl";
 import { formatUnits } from "viem";
 import { useGetQuote } from "../../hooks";
+import { TransactionInfo } from "../types";
 
 // NOTE: When the tradeType is exactOut we must refetch the quote with exactIn because the
 // quoteGas values are the values we display in top token input field.
@@ -47,7 +48,7 @@ const useTxnQuote = (inputOne: TokenInputState, inputTwo: TokenInputState) => {
  * Returns the price impact as a decimal (e.g. -0.002 means -0.2%).
  */
 const calculatePriceImpact = (txnQuoteData: GetQuoteResult): number => {
-  const hops = txnQuoteData?.route?.[0];
+  const hops = txnQuoteData.route?.[0];
 
   if (!hops) {
     return 0;
@@ -144,7 +145,7 @@ export const useTxnInfo = ({
   bottomToken: TokenInputState;
   tradeType: TRADE_TYPE;
   validSwapInputs: boolean;
-}) => {
+}): TransactionInfo => {
   const { formatNumber } = useIntl();
   const { txnQuote, txnQuoteLoading, fetchTxnQuote } = useTxnQuote(
     topToken,
@@ -173,7 +174,7 @@ export const useTxnInfo = ({
       parseFloat(
         formatUnits(
           BigInt(txnQuoteData?.quoteGasAdjusted || "0"),
-          bottomToken?.token?.coinDecimals || 18,
+          bottomToken.token?.coinDecimals || 18,
         ),
       ),
       { minimumFractionDigits: 6, maximumFractionDigits: 6 },

--- a/apps/flame-defi/app/swap/hooks/use-usd-quote.tsx
+++ b/apps/flame-defi/app/swap/hooks/use-usd-quote.tsx
@@ -5,7 +5,7 @@ import { useEvmChainData } from "config";
 import { EvmCurrency, TokenInputState, TRADE_TYPE } from "@repo/flame-types";
 import { useGetQuote } from "../../hooks";
 
-export const useUsdQuote = (inputToken?: TokenInputState) => {
+export const useUsdQuote = (inputToken: TokenInputState) => {
   const { selectedChain } = useEvmChainData();
   const usdcToken = selectedChain.currencies?.find(
     (currency) => currency.coinDenom === "USDC",
@@ -15,23 +15,21 @@ export const useUsdQuote = (inputToken?: TokenInputState) => {
   const debouncedGetQuoteRef = useRef(
     debounce(
       (
-        tradeType: TRADE_TYPE,
-        tokenData: { token: EvmCurrency; value: string },
+        inputToken: Omit<TokenInputState, "isQuoteValue">,
         usdcToken: EvmCurrency,
       ) => {
-        getQuote(tradeType, tokenData, { token: usdcToken, value: "" });
+        void getQuote(TRADE_TYPE.EXACT_IN, inputToken, {
+          token: usdcToken,
+          value: "",
+        });
       },
       500,
     ),
   );
 
   useEffect(() => {
-    if (inputToken && inputToken.token && inputToken.value && usdcToken) {
-      debouncedGetQuoteRef.current(
-        TRADE_TYPE.EXACT_IN,
-        { token: inputToken.token, value: inputToken.value },
-        usdcToken,
-      );
+    if (inputToken.value !== "0" && usdcToken) {
+      debouncedGetQuoteRef.current(inputToken, usdcToken);
     }
   }, [inputToken, usdcToken]);
 

--- a/apps/flame-defi/app/swap/hooks/use-usd-quote.tsx
+++ b/apps/flame-defi/app/swap/hooks/use-usd-quote.tsx
@@ -7,7 +7,7 @@ import { useGetQuote } from "../../hooks";
 
 export const useUsdQuote = (inputToken: TokenInputState) => {
   const { selectedChain } = useEvmChainData();
-  const usdcToken = selectedChain.currencies?.find(
+  const usdcToken = selectedChain.currencies.find(
     (currency) => currency.coinDenom === "USDC",
   );
   const { quote, loading, quoteError, getQuote } = useGetQuote();

--- a/apps/flame-defi/app/swap/page.tsx
+++ b/apps/flame-defi/app/swap/page.tsx
@@ -33,7 +33,7 @@ export default function SwapPage(): React.ReactElement {
   const userAccount = useAccount();
   const [modalOpen, setModalOpen] = useState<boolean>(false);
   const [inputOne, setInputOne] = useState<TokenInputState>({
-    token: currencies?.[0],
+    token: currencies[0],
     value: "",
     isQuoteValue: false,
   });

--- a/apps/flame-defi/app/swap/page.tsx
+++ b/apps/flame-defi/app/swap/page.tsx
@@ -306,7 +306,6 @@ export default function SwapPage(): React.ReactElement {
     if (newTopTokenInput.value !== "" || newBottomTokenInput.value !== "") {
       getQuote(newTradeType, newTopTokenInput, newBottomTokenInput).then(
         (res) => {
-          console.log(res);
           if (inputOne.isQuoteValue && res) {
             setInputOne((prev) => ({ ...prev, value: res.quoteDecimals }));
           } else if (inputTwo.isQuoteValue && res) {

--- a/apps/flame-defi/app/swap/page.tsx
+++ b/apps/flame-defi/app/swap/page.tsx
@@ -25,7 +25,7 @@ import { useOneToOneQuote, useSwapButton, useTxnInfo } from "./hooks";
 import { SwapInput, SwapTxnSteps, TxnInfo } from "./components";
 import { useTokenBalances } from "features/evm-wallet";
 import debounce from "lodash.debounce";
-import { SwapPairProps, TOKEN_INPUTS } from "./types";
+import { SwapPairProps, SWAP_INPUT_ID } from "./types";
 
 export default function SwapPage(): React.ReactElement {
   const { selectedChain } = useEvmChainData();
@@ -62,14 +62,14 @@ export default function SwapPage(): React.ReactElement {
 
   const swapInputs: SwapPairProps[] = [
     {
-      id: TOKEN_INPUTS.INPUT_ONE,
+      id: SWAP_INPUT_ID.INPUT_ONE,
       inputToken: inputOne,
       oppositeToken: inputTwo,
       balance: balances[0]?.value || "0",
       label: flipTokens ? "Buy" : "Sell",
     },
     {
-      id: TOKEN_INPUTS.INPUT_TWO,
+      id: SWAP_INPUT_ID.INPUT_TWO,
       inputToken: inputTwo,
       oppositeToken: inputOne,
       balance: balances[1]?.value || "0",
@@ -131,16 +131,16 @@ export default function SwapPage(): React.ReactElement {
         tradeType: TRADE_TYPE,
         tokenIn: TokenInputState,
         tokenOut: TokenInputState,
-        tokenInput: TOKEN_INPUTS,
+        inputId: SWAP_INPUT_ID,
       ) => {
         getQuote(tradeType, tokenIn, tokenOut).then((res) => {
-          if (tokenInput === TOKEN_INPUTS.INPUT_ONE && res) {
+          if (inputId === SWAP_INPUT_ID.INPUT_ONE && res) {
             setInputTwo((prev) => ({
               ...prev,
               value: res.quoteDecimals,
               isQuoteValue: true,
             }));
-          } else if (tokenInput === TOKEN_INPUTS.INPUT_TWO && res) {
+          } else if (inputId === SWAP_INPUT_ID.INPUT_TWO && res) {
             setInputOne((prev) => ({
               ...prev,
               value: res.quoteDecimals,
@@ -169,7 +169,7 @@ export default function SwapPage(): React.ReactElement {
   }, [setQuote, setTxnStatus, topToken, bottomToken]);
 
   const handleInputChange = useCallback(
-    (value: string, tokenInput: TOKEN_INPUTS) => {
+    (value: string, inputId: SWAP_INPUT_ID) => {
       setErrorText(null);
 
       // clear all values and cancel any current getQuotes if user zeros input
@@ -184,13 +184,13 @@ export default function SwapPage(): React.ReactElement {
       let newInputOne = inputOne;
       let newInputTwo = inputTwo;
 
-      if (tokenInput === TOKEN_INPUTS.INPUT_ONE) {
+      if (inputId === SWAP_INPUT_ID.INPUT_ONE) {
         newInputOne = { ...inputOne, value, isQuoteValue: false };
         // zero out the other input's value and set it as the quoted value when user types in an input
         newInputTwo = { ...inputTwo, value: "", isQuoteValue: true };
         setInputOne(newInputOne);
         setInputTwo(newInputTwo);
-      } else if (tokenInput === TOKEN_INPUTS.INPUT_TWO) {
+      } else if (inputId === SWAP_INPUT_ID.INPUT_TWO) {
         newInputTwo = { ...inputTwo, value, isQuoteValue: false };
         // zero out the other input's value and set it as the quoted value when user types in an input
         newInputOne = { ...inputOne, value: "", isQuoteValue: true };
@@ -228,7 +228,7 @@ export default function SwapPage(): React.ReactElement {
           newTradeType,
           newTopTokenInput,
           newBottomTokenInput,
-          tokenInput,
+          inputId,
         );
       }
     },
@@ -239,7 +239,7 @@ export default function SwapPage(): React.ReactElement {
     (
       selectedToken: EvmCurrency,
       oppositeTokenInput: TokenInputState,
-      tokenInput: TOKEN_INPUTS,
+      inputId: SWAP_INPUT_ID,
     ) => {
       setErrorText(null);
 
@@ -248,10 +248,10 @@ export default function SwapPage(): React.ReactElement {
       let newInputOne = inputOne;
       let newInputTwo = inputTwo;
 
-      if (tokenInput === TOKEN_INPUTS.INPUT_ONE) {
+      if (inputId === SWAP_INPUT_ID.INPUT_ONE) {
         newInputOne = { ...inputOne, token: selectedToken };
         setInputOne(newInputOne);
-      } else if (tokenInput === TOKEN_INPUTS.INPUT_TWO) {
+      } else if (inputId === SWAP_INPUT_ID.INPUT_TWO) {
         newInputTwo = { ...inputTwo, token: selectedToken };
         setInputTwo(newInputTwo);
       }

--- a/apps/flame-defi/app/swap/page.tsx
+++ b/apps/flame-defi/app/swap/page.tsx
@@ -312,7 +312,7 @@ export default function SwapPage(): React.ReactElement {
           } else if (inputTwo.isQuoteValue && res) {
             setInputTwo((prev) => ({ ...prev, value: res.quoteDecimals }));
           }
-        }
+        },
       );
     }
   };

--- a/apps/flame-defi/app/swap/page.tsx
+++ b/apps/flame-defi/app/swap/page.tsx
@@ -17,14 +17,15 @@ import {
   EvmCurrency,
   TokenInputState,
   TRADE_TYPE,
+  TRADE_TYPE_OPPOSITES,
   TXN_STATUS,
 } from "@repo/flame-types";
 import { useGetQuote } from "../hooks";
-import { useSwapButton, useOneToOneQuote, useTxnInfo } from "./hooks";
-import { SwapTxnSteps, SwapInput, TxnInfo } from "./components";
+import { useOneToOneQuote, useSwapButton, useTxnInfo } from "./hooks";
+import { SwapInput, SwapTxnSteps, TxnInfo } from "./components";
 import { useTokenBalances } from "features/evm-wallet";
 import debounce from "lodash.debounce";
-import { TOKEN_INPUTS, SwapPairProps } from "./types";
+import { SwapPairProps, TOKEN_INPUTS } from "./types";
 
 export default function SwapPage(): React.ReactElement {
   const { selectedChain } = useEvmChainData();
@@ -47,7 +48,7 @@ export default function SwapPage(): React.ReactElement {
       (inputOne.token?.isNative && inputTwo.token?.isWrappedNative) ||
         (inputOne.token?.isWrappedNative && inputTwo.token?.isNative),
     );
-  }, [inputOne, inputTwo]);
+  }, [inputOne.token, inputTwo.token]);
 
   const [flipTokens, setFlipTokens] = useState(false);
   const [tradeType, setTradeType] = useState<TRADE_TYPE>(TRADE_TYPE.EXACT_IN);
@@ -65,14 +66,14 @@ export default function SwapPage(): React.ReactElement {
       inputToken: inputOne,
       oppositeToken: inputTwo,
       balance: balances[0]?.value || "0",
-      label: flipTokens ? "Sell" : "Buy",
+      label: flipTokens ? "Buy" : "Sell",
     },
     {
       id: TOKEN_INPUTS.INPUT_TWO,
       inputToken: inputTwo,
       oppositeToken: inputOne,
       balance: balances[1]?.value || "0",
-      label: flipTokens ? "Buy" : "Sell",
+      label: flipTokens ? "Sell" : "Buy",
     },
   ];
 
@@ -82,7 +83,6 @@ export default function SwapPage(): React.ReactElement {
   ];
   const topToken = swapPairs[0].inputToken;
   const bottomToken = swapPairs[1].inputToken;
-  const userInputToken = !topToken.isQuoteValue ? topToken : bottomToken;
 
   useEffect(() => {
     if (userAccount.address && (inputOne.token || inputTwo.token)) {
@@ -129,11 +129,11 @@ export default function SwapPage(): React.ReactElement {
     debounce(
       (
         tradeType: TRADE_TYPE,
-        tokenData: { token: EvmCurrency; value: string },
-        token: TokenInputState,
+        tokenIn: TokenInputState,
+        tokenOut: TokenInputState,
         tokenInput: TOKEN_INPUTS,
       ) => {
-        getQuote(tradeType, tokenData, token).then((res) => {
+        getQuote(tradeType, tokenIn, tokenOut).then((res) => {
           if (tokenInput === TOKEN_INPUTS.INPUT_ONE && res) {
             setInputTwo((prev) => ({
               ...prev,
@@ -153,15 +153,9 @@ export default function SwapPage(): React.ReactElement {
     ),
   );
 
-  const handleTradeType = useCallback((index: number) => {
-    if (index === 0) {
-      setTradeType(TRADE_TYPE.EXACT_IN);
-    } else if (index === 1) {
-      setTradeType(TRADE_TYPE.EXACT_OUT);
-    }
-  }, []);
-
-  const handleTiaWtiaInputs = (value: string) => {
+  // the native currency and wrapped tokens are always the same price,
+  // so update inputOne and inputTwo with the same value
+  const handleWhenNativeAndWrapped = (value: string) => {
     setInputOne((prev) => ({ ...prev, value: value }));
     setInputTwo((prev) => ({ ...prev, value: value }));
   };
@@ -175,133 +169,145 @@ export default function SwapPage(): React.ReactElement {
   }, [setQuote, setTxnStatus, topToken, bottomToken]);
 
   const handleInputChange = useCallback(
-    (value: string, tokenInput: TOKEN_INPUTS, index: number) => {
-      if (isTiaWtia) {
-        handleTiaWtiaInputs(value);
-        return;
-      }
+    (value: string, tokenInput: TOKEN_INPUTS) => {
       setErrorText(null);
-      handleTradeType(index);
 
-      const tradeType =
-        index === 0 ? TRADE_TYPE.EXACT_IN : TRADE_TYPE.EXACT_OUT;
-
-      if (tokenInput === TOKEN_INPUTS.INPUT_ONE) {
-        setInputOne((prev) => ({ ...prev, value: value, isQuoteValue: false }));
-        setInputTwo((prev) => ({ ...prev, value: "", isQuoteValue: true }));
-      } else if (tokenInput === TOKEN_INPUTS.INPUT_TWO) {
-        setInputTwo((prev) => ({ ...prev, value: value, isQuoteValue: false }));
-        setInputOne((prev) => ({ ...prev, value: "", isQuoteValue: true }));
-      }
-
-      if (
-        value !== "" &&
-        parseFloat(value) > 0 &&
-        topToken.token &&
-        bottomToken.token
-      ) {
-        debouncedGetQuoteRef.current(
-          tradeType,
-          { token: topToken.token, value },
-          bottomToken,
-          tokenInput,
-        );
-      }
-
+      // clear all values and cancel any current getQuotes if user zeros input
       if (value === "" || value === "0") {
         setInputOne((prev) => ({ ...prev, value: value }));
         setInputTwo((prev) => ({ ...prev, value: value }));
         cancelGetQuote();
       }
+
+      // we won't have up-to-date inputs after setting them in state,
+      // so calculate them here so we can use them to get the quote
+      let newInputOne = inputOne;
+      let newInputTwo = inputTwo;
+
+      if (tokenInput === TOKEN_INPUTS.INPUT_ONE) {
+        newInputOne = { ...inputOne, value, isQuoteValue: false };
+        // zero out the other input's value and set it as the quoted value when user types in an input
+        newInputTwo = { ...inputTwo, value: "", isQuoteValue: true };
+        setInputOne(newInputOne);
+        setInputTwo(newInputTwo);
+      } else if (tokenInput === TOKEN_INPUTS.INPUT_TWO) {
+        newInputTwo = { ...inputTwo, value, isQuoteValue: false };
+        // zero out the other input's value and set it as the quoted value when user types in an input
+        newInputOne = { ...inputOne, value: "", isQuoteValue: true };
+        setInputTwo(newInputTwo);
+        setInputOne(newInputOne);
+      }
+
+      if (
+        (newInputOne.token?.isNative && newInputTwo.token?.isWrappedNative) ||
+        (newInputOne.token?.isWrappedNative && newInputTwo.token?.isNative)
+      ) {
+        handleWhenNativeAndWrapped(value);
+        // we don't need to get a quote if we're wrapping/unwrapping,
+        // so we can return early
+        return;
+      }
+
+      const newTopTokenInput = flipTokens ? newInputTwo : newInputOne;
+      const newBottomTokenInput = flipTokens ? newInputOne : newInputTwo;
+      const tradeType = newTopTokenInput.isQuoteValue
+        ? TRADE_TYPE.EXACT_OUT
+        : TRADE_TYPE.EXACT_IN;
+
+      setTradeType(tradeType);
+
+      const exactInWithValue =
+        tradeType === TRADE_TYPE.EXACT_IN && newTopTokenInput.value !== "0";
+      const exactOutWithValue =
+        tradeType === TRADE_TYPE.EXACT_OUT && newBottomTokenInput.value !== "0";
+
+      if (exactInWithValue || exactOutWithValue) {
+        debouncedGetQuoteRef.current(
+          tradeType,
+          newTopTokenInput,
+          newBottomTokenInput,
+          tokenInput,
+        );
+      }
     },
-    [
-      topToken,
-      bottomToken,
-      handleTradeType,
-      isTiaWtia,
-      debouncedGetQuoteRef,
-      cancelGetQuote,
-      setErrorText,
-    ],
+    [setErrorText, inputOne, inputTwo, flipTokens, cancelGetQuote],
   );
 
   const handleTokenSelect = useCallback(
-    (selectedToken: EvmCurrency, tokenInput: TOKEN_INPUTS, index: number) => {
-      const oppositeInputToken =
-        tokenInput === TOKEN_INPUTS.INPUT_ONE ? bottomToken : topToken;
-      if (
-        (selectedToken.isNative && oppositeInputToken.token?.isWrappedNative) ||
-        (selectedToken.isWrappedNative && oppositeInputToken.token?.isNative)
-      ) {
-        const value =
-          tokenInput === TOKEN_INPUTS.INPUT_ONE
-            ? bottomToken.value
-            : topToken.value;
-        handleTiaWtiaInputs(value);
-      }
-
-      if (tokenInput === TOKEN_INPUTS.INPUT_ONE) {
-        setInputOne((prev) => ({ ...prev, token: selectedToken }));
-      } else if (tokenInput === TOKEN_INPUTS.INPUT_TWO) {
-        setInputTwo((prev) => ({ ...prev, token: selectedToken }));
-      }
-
+    (
+      selectedToken: EvmCurrency,
+      oppositeTokenInput: TokenInputState,
+      tokenInput: TOKEN_INPUTS,
+    ) => {
       setErrorText(null);
 
-      const tradeType = topToken.isQuoteValue
-        ? TRADE_TYPE.EXACT_OUT
-        : TRADE_TYPE.EXACT_IN;
-      const exactInToken = index === 0 ? selectedToken : topToken.token;
-      const exactOutToken =
-        index === 0 && bottomToken.token ? bottomToken.token : selectedToken;
+      // we won't have up-to-date inputs after setting them in state,
+      // so calculate them here so we can use them to get the quote
+      let newInputOne = inputOne;
+      let newInputTwo = inputTwo;
+
+      if (tokenInput === TOKEN_INPUTS.INPUT_ONE) {
+        newInputOne = { ...inputOne, token: selectedToken };
+        setInputOne(newInputOne);
+      } else if (tokenInput === TOKEN_INPUTS.INPUT_TWO) {
+        newInputTwo = { ...inputTwo, token: selectedToken };
+        setInputTwo(newInputTwo);
+      }
 
       if (
-        userInputToken.value !== "" &&
-        parseFloat(userInputToken.value) > 0 &&
-        exactInToken &&
-        exactOutToken
+        (newInputOne.token?.isNative && newInputTwo.token?.isWrappedNative) ||
+        (newInputOne.token?.isWrappedNative && newInputTwo.token?.isNative)
       ) {
-        getQuote(
-          tradeType,
-          { token: exactInToken, value: userInputToken.value },
-          { token: exactOutToken, value: "" },
-        ).then((res) => {
-          if (inputOne.isQuoteValue && res) {
-            setInputOne((prev) => ({ ...prev, value: res.quoteDecimals }));
-          } else if (inputTwo.isQuoteValue && res) {
-            setInputTwo((prev) => ({ ...prev, value: res.quoteDecimals }));
-          }
-        });
+        handleWhenNativeAndWrapped(oppositeTokenInput.value);
+        // we don't need to get a quote if we're wrapping/unwrapping,
+        // so we can return early
+        return;
       }
-    },
-    [
-      getQuote,
-      topToken,
-      bottomToken,
-      setErrorText,
-      userInputToken,
-      inputOne,
-      inputTwo,
-    ],
-  );
 
-  const handleArrowClick = () => {
-    const newTradeType =
-      tradeType === TRADE_TYPE.EXACT_IN
+      const newTopTokenInput = flipTokens ? newInputTwo : newInputOne;
+      const newBottomTokenInput = flipTokens ? newInputOne : newInputTwo;
+      const tradeType = newTopTokenInput.isQuoteValue
         ? TRADE_TYPE.EXACT_OUT
         : TRADE_TYPE.EXACT_IN;
-    setFlipTokens((prev) => !prev);
+
+      const exactInWithValue =
+        tradeType === TRADE_TYPE.EXACT_IN && newTopTokenInput.value !== "0";
+      const exactOutWithValue =
+        tradeType === TRADE_TYPE.EXACT_OUT && newBottomTokenInput.value !== "0";
+
+      if (exactInWithValue || exactOutWithValue) {
+        getQuote(tradeType, newTopTokenInput, newBottomTokenInput).then(
+          (res) => {
+            if (newInputOne.isQuoteValue && res) {
+              setInputOne((prev) => ({ ...prev, value: res.quoteDecimals }));
+            } else if (newInputTwo.isQuoteValue && res) {
+              setInputTwo((prev) => ({ ...prev, value: res.quoteDecimals }));
+            }
+          },
+        );
+      }
+    },
+    [inputOne, inputTwo, setErrorText, flipTokens, getQuote],
+  );
+
+  // toggle tradeType and flipTokens and get new quote accordingly
+  const handleArrowClick = () => {
+    const newTradeType = TRADE_TYPE_OPPOSITES[tradeType];
+    const newFlipTokens = !flipTokens;
+
+    // determine what the next topToken and bottomToken will be based on the
+    // new flipTokens value and use them to get a quote
+    const nextTopToken = newFlipTokens ? inputTwo : inputOne;
+    const nextBottomToken = newFlipTokens ? inputOne : inputTwo;
+
     setTradeType(newTradeType);
+    setFlipTokens(newFlipTokens);
 
-    const preFlipTokenOne = !flipTokens ? inputTwo : inputOne;
-    const preFlipTokenTwo = !flipTokens ? inputOne : inputTwo;
-
-    if (preFlipTokenOne.value !== "" || preFlipTokenTwo.value !== "") {
-      getQuote(
-        newTradeType,
-        { token: preFlipTokenOne.token, value: userInputToken.value },
-        preFlipTokenTwo,
-      );
+    if (nextTopToken.value !== "" || nextBottomToken.value !== "") {
+      // FIXME - when the arrow is clicked, the isQuoteValue value gets cleared.
+      //  where does this happen at? or is it just hidden because of loading state
+      //  in SwapInput?
+      getQuote(newTradeType, nextTopToken, nextBottomToken);
     }
   };
 
@@ -348,7 +354,6 @@ export default function SwapPage(): React.ReactElement {
                   availableTokens={currencies}
                   balance={balance}
                   id={id}
-                  index={index}
                   inputToken={inputToken}
                   key={index}
                   label={label}

--- a/apps/flame-defi/app/swap/types.ts
+++ b/apps/flame-defi/app/swap/types.ts
@@ -1,5 +1,4 @@
 import { EvmCurrency, TokenInputState, TXN_STATUS } from "@repo/flame-types";
-import { useTxnInfo } from "./hooks";
 
 export enum TOKEN_INPUTS {
   INPUT_ONE = "input_one",
@@ -25,9 +24,9 @@ export interface SwapPairProps {
 
 export interface TxnStepsProps {
   expectedOutputFormatted?: string;
-  topToken?: TokenInputState;
-  bottomToken?: TokenInputState;
-  isTiaWtia?: boolean;
+  topToken: TokenInputState;
+  bottomToken: TokenInputState;
+  isTiaWtia: boolean;
   txnHash?: `0x${string}`;
   txnMsg?: string;
 }
@@ -38,8 +37,18 @@ export interface TxnDetailsProps extends TxnStepsProps {
   oneToOneQuote: OneToOneQuoteProps;
 }
 
+export interface TransactionInfo {
+  txnQuoteDataLoading: boolean;
+  gasUseEstimateUSD: string | undefined;
+  formattedGasUseEstimateUSD: string;
+  expectedOutputBigInt: bigint;
+  expectedOutputFormatted: string;
+  priceImpact: string;
+  minimumReceived: string;
+}
+
 export interface SwapTxnStepsProps {
-  txnInfo: ReturnType<typeof useTxnInfo>;
+  txnInfo: TransactionInfo;
   topToken: TokenInputState;
   bottomToken: TokenInputState;
   txnStatus: TXN_STATUS | undefined;

--- a/apps/flame-defi/app/swap/types.ts
+++ b/apps/flame-defi/app/swap/types.ts
@@ -39,7 +39,7 @@ export interface TxnDetailsProps extends TxnStepsProps {
 
 export interface TransactionInfo {
   txnQuoteDataLoading: boolean;
-  gasUseEstimateUSD: string | undefined;
+  gasUseEstimateUSD: string;
   formattedGasUseEstimateUSD: string;
   expectedOutputBigInt: bigint;
   expectedOutputFormatted: string;

--- a/apps/flame-defi/app/swap/types.ts
+++ b/apps/flame-defi/app/swap/types.ts
@@ -50,18 +50,13 @@ export interface SwapTxnStepsProps {
 }
 
 export interface SwapInputProps extends SwapPairProps {
-  onInputChange: (
-    value: string,
-    tokenInput: TOKEN_INPUTS,
-    index: number,
-  ) => void;
+  onInputChange: (value: string, tokenInput: TOKEN_INPUTS) => void;
   onTokenSelect: (
     token: EvmCurrency,
+    oppositeToken: TokenInputState,
     tokenInput: TOKEN_INPUTS,
-    index: number,
   ) => void;
   availableTokens: EvmCurrency[];
-  index: number;
   label: string;
   txnQuoteLoading: boolean;
 }

--- a/apps/flame-defi/app/swap/types.ts
+++ b/apps/flame-defi/app/swap/types.ts
@@ -1,6 +1,6 @@
 import { EvmCurrency, TokenInputState, TXN_STATUS } from "@repo/flame-types";
 
-export enum TOKEN_INPUTS {
+export enum SWAP_INPUT_ID {
   INPUT_ONE = "input_one",
   INPUT_TWO = "input_two",
 }
@@ -15,7 +15,7 @@ export interface OneToOneQuoteProps {
 }
 
 export interface SwapPairProps {
-  id: TOKEN_INPUTS;
+  id: SWAP_INPUT_ID;
   inputToken: TokenInputState;
   oppositeToken: TokenInputState;
   balance: string;
@@ -59,11 +59,11 @@ export interface SwapTxnStepsProps {
 }
 
 export interface SwapInputProps extends SwapPairProps {
-  onInputChange: (value: string, tokenInput: TOKEN_INPUTS) => void;
+  onInputChange: (value: string, inputId: SWAP_INPUT_ID) => void;
   onTokenSelect: (
     token: EvmCurrency,
     oppositeToken: TokenInputState,
-    tokenInput: TOKEN_INPUTS,
+    inputId: SWAP_INPUT_ID,
   ) => void;
   availableTokens: EvmCurrency[];
   label: string;

--- a/packages/flame-types/src/types.ts
+++ b/packages/flame-types/src/types.ts
@@ -604,6 +604,12 @@ export enum TRADE_TYPE {
   EXACT_OUT = "exactOut",
 }
 
+// TODO - replace all ternaries that get opposite tradeType with this type usage
+export const TRADE_TYPE_OPPOSITES: Record<TRADE_TYPE, TRADE_TYPE> = {
+  [TRADE_TYPE.EXACT_IN]: TRADE_TYPE.EXACT_OUT,
+  [TRADE_TYPE.EXACT_OUT]: TRADE_TYPE.EXACT_IN,
+};
+
 export enum TXN_STATUS {
   IDLE = "idle",
   PENDING = "pending",

--- a/packages/flame-types/src/types.ts
+++ b/packages/flame-types/src/types.ts
@@ -604,7 +604,6 @@ export enum TRADE_TYPE {
   EXACT_OUT = "exactOut",
 }
 
-// TODO - replace all ternaries that get opposite tradeType with this type usage
 export const TRADE_TYPE_OPPOSITES: Record<TRADE_TYPE, TRADE_TYPE> = {
   [TRADE_TYPE.EXACT_IN]: TRADE_TYPE.EXACT_OUT,
   [TRADE_TYPE.EXACT_OUT]: TRADE_TYPE.EXACT_IN,


### PR DESCRIPTION
Resolves #103
Resolves #111 

* renames TOKEN_INPUTS to SWAP_INPUT_ID
* gets rid of all unnecessary optional chain operators
* refactors some types and logic to be more type safe
* calculating newTopToken and newBottomToken in handlers because topToken and bottomToken are not yet updated
* a lot of renaming for clarity and consistency
* fixes backwards "Buy" and "Sell" labels
* explicit use of `void` in front of promises where we don't `await` or `.then()`
* sets values from quote from clicking flip tokens button

short description of what happened:
- sending wrong amount to api
- not using the correct token's decimals to calculate the amount
	- USDC uses 6 decimal places, but `amount` was calculated using the wrong token
- led to bigger refactor because of how we're passing data to `getQuote`
	- i refactored `getQuote` to calculate `value` based on the `tradeType`
	- then noticed we were previously always setting `value` on the first token passed to `getQuote`
	- refactored usage of `getQuote` to correctly pass in `tokenIn` and `tokenOut`
	- still had an issue in `handleInputChange` where we set inputs and then immediately try to use `topToken` or `bottomToken` but i don't think they are updated yet
	- refactored input handlers to determine new top and bottom token and call `getQuote` with these new top and bottom tokens