### PR TITLE
Feat/custom lint prefer optional syntax

### DIFF
--- a/apps/flame-defi/app/features/cosmos-wallet/contexts/cosmos-wallet-context.tsx
+++ b/apps/flame-defi/app/features/cosmos-wallet/contexts/cosmos-wallet-context.tsx
@@ -23,7 +23,7 @@ export interface CosmosWalletContextProps {
   cosmosAccountAddress: string | null;
   cosmosBalance: { value: string; symbol: string } | null;
   cosmosChainsOptions: DropdownOption<CosmosChainInfo>[];
-  defaultIbcCurrencyOption: DropdownOption<IbcCurrency> | undefined;
+  defaultIbcCurrencyOption?: DropdownOption<IbcCurrency>;
   disconnectCosmosWallet: () => void;
   getCosmosSigningClient: () => Promise<SigningStargateClient>;
   ibcCurrencyOptions: DropdownOption<IbcCurrency>[];

--- a/apps/flame-defi/app/features/evm-wallet/contexts/evm-wallet-context.tsx
+++ b/apps/flame-defi/app/features/evm-wallet/contexts/evm-wallet-context.tsx
@@ -43,7 +43,7 @@ import { createErc20Service } from "../services/erc-20-service/erc-20-service";
 
 export interface EvmWalletContextProps {
   connectEvmWallet: () => void;
-  defaultEvmCurrencyOption: DropdownOption<EvmCurrency> | undefined;
+  defaultEvmCurrencyOption?: DropdownOption<EvmCurrency>;
   disconnectEvmWallet: () => void;
   evmAccountAddress: string | null;
   evmChainsOptions: DropdownOption<EvmChainInfo>[];
@@ -53,7 +53,7 @@ export interface EvmWalletContextProps {
   isLoadingSelectedEvmCurrencyBalance: boolean;
   resetState: () => void;
   selectedEvmChain: EvmChainInfo | null;
-  selectedEvmChainNativeToken: EvmCurrency | undefined;
+  selectedEvmChainNativeToken?: EvmCurrency;
   selectedEvmChainOption: DropdownOption<EvmChainInfo> | null;
   selectedEvmCurrency: EvmCurrency | null;
   selectedEvmCurrencyBalance: { value: string; symbol: string } | null;

--- a/apps/flame-defi/app/features/evm-wallet/hooks/use-token-balances.tsx
+++ b/apps/flame-defi/app/features/evm-wallet/hooks/use-token-balances.tsx
@@ -6,8 +6,8 @@ import { formatUnits } from "viem";
 import { useConfig, useBalance } from "wagmi";
 
 export const useTokenBalances = (
-  userAddress: HexString | undefined,
-  evmChain: EvmChainInfo | undefined,
+  userAddress?: HexString,
+  evmChain?: EvmChainInfo,
 ) => {
   const wagmiConfig = useConfig();
   const [balances, setBalances] = useState<

--- a/apps/flame-defi/app/hooks/use-token-approval.tsx
+++ b/apps/flame-defi/app/hooks/use-token-approval.tsx
@@ -10,7 +10,7 @@ export const useTokenApproval = ({
 }: {
   tokenNeedingApproval: TokenInputState | null;
   setTxnStatus: (status: TXN_STATUS) => void;
-  setTxnHash: (hash: HexString | undefined) => void;
+  setTxnHash: (hash?: HexString) => void;
   setErrorText: (error: string) => void;
 }) => {
   const { tokenApprovalAmount } = useConfig();

--- a/apps/flame-defi/app/swap/types.ts
+++ b/apps/flame-defi/app/swap/types.ts
@@ -11,9 +11,9 @@ export enum SWAP_INPUT_ID {
 }
 
 export interface OneToOneQuoteProps {
-  topTokenSymbol: string | undefined;
-  bottomTokenSymbol: string | undefined;
-  bottomTokenValue: string | undefined;
+  topTokenSymbol?: string;
+  bottomTokenSymbol?: string;
+  bottomTokenValue?: string;
   oneToOneLoading: boolean;
   flipDirection: boolean;
   setFlipDirection: (flipDirection: boolean) => void;
@@ -37,8 +37,8 @@ export interface TxnStepsProps {
 }
 
 export interface TxnDetailsProps extends TxnStepsProps {
-  priceImpact: string | undefined;
-  minimumReceived: string | undefined;
+  priceImpact?: string;
+  minimumReceived?: string;
   oneToOneQuote: OneToOneQuoteProps;
   isQuoteLoading: boolean;
   frontendFeeEstimate?: string;
@@ -59,9 +59,9 @@ export interface SwapTxnStepsProps {
   txnInfo: TransactionInfo;
   topToken: TokenInputState;
   bottomToken: TokenInputState;
-  txnStatus: TXN_STATUS | undefined;
-  txnHash: HexString | undefined;
-  txnMsg: string | undefined;
+  txnStatus?: TXN_STATUS;
+  txnHash?: HexString;
+  txnMsg?: string;
   isTiaWtia: boolean;
   oneToOneQuote: OneToOneQuoteProps;
   isQuoteLoading: boolean;

--- a/packages/eslint-config/base.js
+++ b/packages/eslint-config/base.js
@@ -3,6 +3,7 @@ import eslintConfigPrettier from "eslint-config-prettier";
 import turboPlugin from "eslint-plugin-turbo";
 import tseslint from "typescript-eslint";
 import onlyWarn from "eslint-plugin-only-warn";
+import { rules as customRules } from "./rules/index.js";
 
 /**
  * A shared ESLint configuration for the repository.
@@ -28,5 +29,15 @@ export const config = [
   },
   {
     ignores: ["dist/**", "coverage/**"],
+  },
+  {
+    plugins: {
+      "@repo": {
+        rules: customRules,
+      },
+    },
+    rules: {
+      "@repo/prefer-optional-syntax": "warn",
+    },
   },
 ];

--- a/packages/eslint-config/rules/index.js
+++ b/packages/eslint-config/rules/index.js
@@ -1,0 +1,5 @@
+import preferOptionalSyntax from "./prefer-optional-syntax.js";
+
+export const rules = {
+  "prefer-optional-syntax": preferOptionalSyntax,
+}

--- a/packages/eslint-config/rules/prefer-optional-syntax.js
+++ b/packages/eslint-config/rules/prefer-optional-syntax.js
@@ -1,0 +1,85 @@
+/**
+ * Rule to enforce using the optional property syntax (prop?: type) instead of union with undefined (prop: type | undefined)
+ */
+export default {
+  meta: {
+    type: "suggestion",
+    docs: {
+      description: "Enforce using the optional property syntax (prop?: type) instead of union with undefined (prop: type | undefined)",
+      category: "TypeScript",
+      recommended: true,
+    },
+    fixable: "code",
+    schema: [],
+  },
+  create(context) {
+    return {
+      TSPropertySignature(node) {
+        // Check if the type annotation is a union type that includes undefined
+        const typeAnnotation = node.typeAnnotation?.typeAnnotation;
+        if (
+          typeAnnotation?.type === "TSUnionType" &&
+          typeAnnotation.types.some(
+            type =>
+              (type.type === "TSUndefinedKeyword") ||
+              (type.type === "TSLiteralType" && type.literal.value === undefined)
+          )
+        ) {
+          context.report({
+            node,
+            message: "Use optional property syntax (prop?: type) instead of union with undefined",
+            fix(fixer) {
+              // Get property name
+              const propertyName = context.getSourceCode().getText(node.key);
+
+              // Create new optional property with the non-undefined types from the union
+              const nonUndefinedTypes = typeAnnotation.types.filter(
+                type =>
+                  type.type !== "TSUndefinedKeyword" &&
+                  !(type.type === "TSLiteralType" && type.literal.value === undefined)
+              );
+
+              // If there's only one type left, use it directly
+              // If there are multiple types, keep them as a union
+              let newType;
+              if (nonUndefinedTypes.length === 1) {
+                newType = context.getSourceCode().getText(nonUndefinedTypes[0]);
+              } else {
+                newType = nonUndefinedTypes
+                  .map(type => context.getSourceCode().getText(type))
+                  .join(" | ");
+              }
+
+              // Build the fixed property with the optional syntax
+              const fixed = `${propertyName}?: ${newType}`;
+
+              // Replace the entire property signature
+              return fixer.replaceText(node, fixed);
+            }
+          });
+        }
+      },
+      // Also check for variable and parameter declarations
+      TSTypeAnnotation(node) {
+        const typeAnnotation = node.typeAnnotation;
+
+        if (
+          typeAnnotation?.type === "TSUnionType" &&
+          typeAnnotation.types.some(
+            type =>
+              (type.type === "TSUndefinedKeyword") ||
+              (type.type === "TSLiteralType" && type.literal.value === undefined)
+          ) &&
+          // Only target variable and parameter declarations, not return types
+          (node.parent.type === "Identifier" ||
+           node.parent.type === "Parameter")
+        ) {
+          context.report({
+            node: node.parent,
+            message: "Consider using optional syntax (prop?: type) instead of union with undefined",
+          });
+        }
+      }
+    };
+  },
+}

--- a/packages/flame-types/src/types.ts
+++ b/packages/flame-types/src/types.ts
@@ -323,7 +323,7 @@ export class EvmCurrency {
    * @param other The other currency to compare with
    * @returns true if the currencies are equal, false otherwise
    */
-  public equals(other: EvmCurrency | null | undefined): boolean {
+  public equals(other?: EvmCurrency | null): boolean {
     if (!other) {
       return false;
     }

--- a/packages/ui/src/components/molecules/copy-to-clipboard-button/copy-to-clipboard-button.tsx
+++ b/packages/ui/src/components/molecules/copy-to-clipboard-button/copy-to-clipboard-button.tsx
@@ -6,7 +6,7 @@ import { ClipboardIcon } from "../../../icons";
 export const CopyToClipboardButton = ({
   textToCopy,
 }: {
-  textToCopy: string | undefined;
+  textToCopy?: string;
 }) => {
   const [copyStatus, setCopyStatus] = useState("");
   const copyToClipboard = (text: string) => {

--- a/packages/ui/src/components/molecules/info-tooltip/info-tooltip.tsx
+++ b/packages/ui/src/components/molecules/info-tooltip/info-tooltip.tsx
@@ -11,7 +11,7 @@ import {
 
 interface InfoTooltipProps {
   content: string;
-  side?: "left" | "right" | "top" | "bottom" | undefined;
+  side?: "left" | "right" | "top" | "bottom";
   className?: string;
 }
 

--- a/packages/ui/src/components/molecules/token-selector/token-selector.tsx
+++ b/packages/ui/src/components/molecules/token-selector/token-selector.tsx
@@ -20,7 +20,7 @@ import {
 import { TokenIcon } from "../token-icon";
 
 interface TokenSelectorProps {
-  tokens: EvmCurrency[] | undefined;
+  tokens?: EvmCurrency[];
   defaultTitle?: string;
   setSelectedToken: (token: EvmCurrency) => void;
   selectedToken?: EvmCurrency | null;


### PR DESCRIPTION
custom eslint rule to prefer optional property syntax `someProp?: number` instead of unions with undefined `someProp: number | undefined`