### PR TITLE
chore: use `viewBoxHeight` instead of fixed value for height

### DIFF
--- a/apps/flame-defi/app/components/navigation-menu/navigation-menu-button.tsx
+++ b/apps/flame-defi/app/components/navigation-menu/navigation-menu-button.tsx
@@ -47,7 +47,7 @@ export const NavigationMenuButton = ({
 
   return (
     <motion.svg
-      viewBox={`0 0 ${viewBoxWidth} ${4}`}
+      viewBox={`0 0 ${viewBoxWidth} ${viewBoxHeight}`}
       overflow="visible"
       width={size}
       height={size}


### PR DESCRIPTION
replaced the hardcoded height value (`4`) with `viewBoxHeight` for better flexibility.