### PR TITLE
fix: use middleware instead of useeffect to redirect to bridge from index

### DIFF
--- a/apps/flame-defi/app/bridge/(routes)/page.tsx
+++ b/apps/flame-defi/app/bridge/(routes)/page.tsx
@@ -1,17 +1,5 @@
-"use client";
-
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
-
-import { ROUTES } from "bridge/constants/routes";
-
+// This component won't typically render because middleware will redirect
+// But it's here as a fallback
 export default function BridgePage() {
-  const router = useRouter();
-
-  useEffect(() => {
-    // Redirect to deposit page by default
-    router.push(ROUTES.DEPOSIT);
-  }, [router]);
-
   return null;
 }

--- a/apps/flame-defi/app/page.tsx
+++ b/apps/flame-defi/app/page.tsx
@@ -1,5 +1,5 @@
-import BridgePage from "./bridge/(routes)/page";
-
+// This component won't typically render because middleware will redirect
+// But it's here as a fallback
 export default function Home() {
-  return <BridgePage />;
+  return null;
 }

--- a/apps/flame-defi/middleware.ts
+++ b/apps/flame-defi/middleware.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+export function middleware(request: NextRequest) {
+  const url = request.nextUrl.clone();
+
+  // Handle exact matches for / and /bridge
+  if (url.pathname === "/" || url.pathname === "/bridge") {
+    url.pathname = "/bridge/deposit";
+    return NextResponse.redirect(url);
+  }
+
+  return NextResponse.next();
+}
+
+// Configure middleware to run only on specific paths
+export const config = {
+  matcher: ["/", "/bridge"],
+};


### PR DESCRIPTION
Using middleware instead of useEffect. No more empty space flashing before redirecting.

Resolves #225