### PR TITLE
feat: disable bridge deposits for non-TIA assets and remove Base chains

### DIFF
--- a/apps/flame-defi/app/bridge/hooks/use-bridge-options.ts
+++ b/apps/flame-defi/app/bridge/hooks/use-bridge-options.ts
@@ -65,7 +65,7 @@ export function useBridgeOptions({
       }
 
       return chain.currencies
-        .filter((c) => c.isBridgeable)
+        .filter((c) => c.isBridgeable && c.coinDenom === "TIA")
         .map((c) => ({
           label: c.coinDenom,
           value: c,
@@ -82,7 +82,7 @@ export function useBridgeOptions({
       }
 
       return chain.currencies
-        .filter((c) => c.isBridgeable)
+        .filter((c) => c.isBridgeable && c.coinDenom === "TIA")
         .map((currency) => ({
           label: currency.coinDenom,
           value: currency,

--- a/apps/flame-defi/app/bridge/modules/deposit/sections/content-section.tsx
+++ b/apps/flame-defi/app/bridge/modules/deposit/sections/content-section.tsx
@@ -10,9 +10,7 @@ import { ChainType, EvmCurrency } from "@repo/flame-types";
 import { AnimatedArrowSpacer } from "@repo/ui/components";
 import {
   ArrowDownIcon,
-  BaseIcon,
   EditIcon,
-  PlusIcon,
   WalletIcon,
 } from "@repo/ui/icons";
 import { shortenAddress } from "@repo/ui/utils";
@@ -178,21 +176,7 @@ export const ContentSection = () => {
   ]);
 
   // additional options
-  const additionalSourceOptions = useMemo(
-    () => [
-      {
-        // TODO - where should the Fund button actually go?
-        label: "Fund with Coinbase OnRamp",
-        action: () => {
-          console.log("Coinbase OnRamp clicked");
-        },
-        className: "text-white",
-        LeftIcon: BaseIcon,
-        RightIcon: PlusIcon,
-      },
-    ],
-    [],
-  );
+  const additionalSourceOptions = useMemo(() => [], []);
 
   // FIXME - should this be an edit button next to the input or something instead?
   //  kinda hard to find as an additional dropdown option

--- a/apps/flame-defi/app/config/chain-configs/chain-configs-dawn.ts
+++ b/apps/flame-defi/app/config/chain-configs/chain-configs-dawn.ts
@@ -11,7 +11,6 @@ import {
 } from "@repo/flame-types";
 import {
   AstriaIcon,
-  BaseIcon,
   CelestiaIcon,
   DropTiaIcon,
   NeutronIcon,
@@ -367,47 +366,4 @@ export const astriaChains: AstriaChains = {
   "Flame Dawn-1": FlameChainInfo,
 };
 
-const BaseChainInfo: EvmChainInfo = {
-  chainType: ChainType.EVM,
-  chainId: 84532,
-  chainName: "Base Sepolia",
-  rpcUrls: ["https://sepolia.base.org"],
-  blockExplorerUrl: "https://sepolia.basescan.org",
-  contracts: {},
-  currencies: [
-    // NOTE - this is really only here to satisfy the config needed
-    //  for wagmi providers. it's not used atm.
-    new EvmCurrency({
-      chainId: 84532,
-      title: "Ether",
-      coinDenom: "ETH",
-      // is gwei correct?
-      coinMinimalDenom: "gwei",
-      coinDecimals: 18,
-      wrapped: null,
-      isNative: true,
-      isWrappedNative: false,
-      isBridgeable: false,
-    }),
-    new EvmCurrency({
-      chainId: 84532,
-      coinDenom: "USDC",
-      title: "USDC",
-      coinMinimalDenom: "uusdc",
-      coinDecimals: 6,
-      erc20ContractAddress: "0x081827b8C3Aa05287b5aA2bC3051fbE638F33152",
-      astriaIntentBridgeAddress: "0x",
-      wrapped: null,
-      isNative: false,
-      isWrappedNative: false,
-      ibcWithdrawalFeeWei: "10000000000000000",
-      isBridgeable: true,
-      IconComponent: UsdcIcon,
-    }),
-  ],
-  IconComponent: BaseIcon,
-};
-
-export const coinbaseChains: CoinbaseChains = {
-  Base: BaseChainInfo,
-};
+export const coinbaseChains: CoinbaseChains = {};

--- a/apps/flame-defi/app/config/chain-configs/chain-configs-dusk.ts
+++ b/apps/flame-defi/app/config/chain-configs/chain-configs-dusk.ts
@@ -11,7 +11,6 @@ import {
 } from "@repo/flame-types";
 import {
   AstriaIcon,
-  BaseIcon,
   CelestiaIcon,
   NobleIcon,
   UsdcIcon,
@@ -295,47 +294,4 @@ export const astriaChains: AstriaChains = {
   "Flame Dusk-11": FlameChainInfo,
 };
 
-const BaseChainInfo: EvmChainInfo = {
-  chainType: ChainType.EVM,
-  chainId: 84532,
-  chainName: "Base Sepolia",
-  rpcUrls: ["https://sepolia.base.org"],
-  blockExplorerUrl: "https://sepolia.basescan.org",
-  contracts: {},
-  currencies: [
-    // NOTE - this is really only here to satisfy the config needed
-    //  for wagmi providers. it's not used atm.
-    new EvmCurrency({
-      chainId: 84532,
-      title: "Ether",
-      coinDenom: "ETH",
-      // is gwei correct?
-      coinMinimalDenom: "gwei",
-      coinDecimals: 18,
-      wrapped: null,
-      isNative: true,
-      isWrappedNative: false,
-      isBridgeable: false,
-    }),
-    new EvmCurrency({
-      chainId: 84532,
-      coinDenom: "USDC",
-      title: "USDC",
-      coinMinimalDenom: "uusdc",
-      coinDecimals: 6,
-      erc20ContractAddress: "0x081827b8C3Aa05287b5aA2bC3051fbE638F33152",
-      astriaIntentBridgeAddress: "0x",
-      wrapped: null,
-      isNative: false,
-      isWrappedNative: false,
-      ibcWithdrawalFeeWei: "10000000000000000",
-      isBridgeable: true,
-      IconComponent: UsdcIcon,
-    }),
-  ],
-  IconComponent: BaseIcon,
-};
-
-export const coinbaseChains: CoinbaseChains = {
-  Base: BaseChainInfo,
-};
+export const coinbaseChains: CoinbaseChains = {};

--- a/apps/flame-defi/app/config/chain-configs/chain-configs-local.ts
+++ b/apps/flame-defi/app/config/chain-configs/chain-configs-local.ts
@@ -11,7 +11,6 @@ import {
 } from "@repo/flame-types";
 import {
   AstriaIcon,
-  BaseIcon,
   CelestiaIcon,
   NobleIcon,
   UsdcIcon,
@@ -320,47 +319,4 @@ export const astriaChains: AstriaChains = {
   Fake: FakeChainInfo,
 };
 
-const BaseChainInfo: EvmChainInfo = {
-  chainType: ChainType.EVM,
-  chainId: 84532,
-  chainName: "Base Sepolia",
-  rpcUrls: ["https://sepolia.base.org"],
-  blockExplorerUrl: "https://sepolia.basescan.org",
-  contracts: {},
-  currencies: [
-    // NOTE - this is really only here to satisfy the config needed
-    //  for wagmi providers. it's not used atm.
-    new EvmCurrency({
-      chainId: 84532,
-      title: "Ether",
-      coinDenom: "ETH",
-      // is gwei correct?
-      coinMinimalDenom: "gwei",
-      coinDecimals: 18,
-      wrapped: null,
-      isNative: true,
-      isWrappedNative: false,
-      isBridgeable: false,
-    }),
-    new EvmCurrency({
-      chainId: 84532,
-      coinDenom: "USDC",
-      title: "USDC",
-      coinMinimalDenom: "uusdc",
-      coinDecimals: 6,
-      erc20ContractAddress: "0x081827b8C3Aa05287b5aA2bC3051fbE638F33152",
-      astriaIntentBridgeAddress: "0x",
-      wrapped: null,
-      isNative: false,
-      isWrappedNative: false,
-      ibcWithdrawalFeeWei: "10000000000000000",
-      isBridgeable: true,
-      IconComponent: UsdcIcon,
-    }),
-  ],
-  IconComponent: BaseIcon,
-};
-
-export const coinbaseChains: CoinbaseChains = {
-  Base: BaseChainInfo,
-};
+export const coinbaseChains: CoinbaseChains = {};

--- a/apps/flame-defi/app/config/chain-configs/chain-configs-mainnet.ts
+++ b/apps/flame-defi/app/config/chain-configs/chain-configs-mainnet.ts
@@ -11,7 +11,6 @@ import {
 } from "@repo/flame-types";
 import {
   AstriaIcon,
-  BaseIcon,
   CelestiaIcon,
   DropTiaIcon,
   MilkTiaIcon,
@@ -458,46 +457,4 @@ export const astriaChains: AstriaChains = {
   Astria: AstriaChainInfo,
 };
 
-const BaseChainInfo: EvmChainInfo = {
-  chainType: ChainType.EVM,
-  chainId: 8453,
-  chainName: "Base",
-  rpcUrls: ["https://mainnet.base.org"],
-  blockExplorerUrl: "https://basescan.org/",
-  contracts: {},
-  currencies: [
-    // NOTE - the native currency is really only here to satisfy the config needed
-    //  for wagmi providers. it's not used atm.
-    new EvmCurrency({
-      chainId: 8453,
-      title: "Ether",
-      coinDenom: "ETH",
-      // is gwei correct?
-      coinMinimalDenom: "gwei",
-      coinDecimals: 18,
-      wrapped: null,
-      isNative: true,
-      isWrappedNative: false,
-      isBridgeable: false,
-    }),
-    new EvmCurrency({
-      chainId: 8453,
-      title: "USDC",
-      coinDenom: "USDC",
-      coinMinimalDenom: "uusdc",
-      coinDecimals: 6,
-      erc20ContractAddress: "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-      astriaIntentBridgeAddress: "0x685e7fEF1f7aF56A972540DE99CaB371cD9f8A87",
-      wrapped: null,
-      isNative: false,
-      isWrappedNative: false,
-      isBridgeable: true,
-      IconComponent: UsdcIcon,
-    }),
-  ],
-  IconComponent: BaseIcon,
-};
-
-export const coinbaseChains: CoinbaseChains = {
-  Base: BaseChainInfo,
-};
+export const coinbaseChains: CoinbaseChains = {};


### PR DESCRIPTION
This PR implements the requirements from issue #268:

- ✅ Disable bridge deposits for all assets that are not TIA
- ✅ Completely remove Base from bridge options
- ✅ Remove "Fund with Coinbase OnRamp" button

## Changes

**Network Configuration:**
- Removed Base chain definitions from all network configs (mainnet, dusk, dawn, local)
- Set coinbaseChains to empty objects across all environments
- Cleaned up unused BaseIcon imports

**Asset Filtering:**
- Modified bridge options to filter currencies by TIA denomination only
- Updated both source and destination currency option generators
- All non-TIA assets (USDC, dTIA, milkTIA, stTIA) are now excluded from deposits

**UI Changes:**
- Removed Coinbase OnRamp button from additional source options
- Cleaned up unused imports (BaseIcon, PlusIcon)

Closes #268

Generated with [Claude Code](https://claude.ai/code)